### PR TITLE
Change "when" to "where" in ex01

### DIFF
--- a/_tutorials/student_ex06.md
+++ b/_tutorials/student_ex06.md
@@ -63,7 +63,7 @@ in a web browser:
 * `target/site/jacoco/index.html`
 
 Unfortunately, that file is only visible on the computer
-when you are running `mvn`.   
+where you are running `mvn`.   
 
 So to make it easier
 for teams to work together, as well as for course staff


### PR DESCRIPTION
The file is visible even when there's no Maven process running; I think the intended meaning was that the file only exists on the local machine, so we should say "the computer where you are running mvn".